### PR TITLE
Remove deprecated Verus Set APIs (new_assuming_finite / .finite())

### DIFF
--- a/source/verismo/src/addr_e/range_interface.rs
+++ b/source/verismo/src/addr_e/range_interface.rs
@@ -430,7 +430,7 @@ pub trait MemRangeSeqInterface {
 }
 
 pub open spec fn empty_ranges() -> Set<(int, nat)> {
-    Set::new_assuming_finite(|r: (int, nat)| r.1 == 0)
+    spec_full_set::<(int, nat)>().filter(|r: (int, nat)| r.1 == 0)
 }
 
 impl<T: MemRangeInterface> MemRangeSeqInterface for Seq<T>
@@ -459,7 +459,7 @@ impl<T: MemRangeInterface> MemRangeSeqInterface for Seq<T>
 
     open spec fn to_valid_ranges_internal(&self) -> Set<(int, nat)> {
         //let s = self.to_range_seq();
-        Set::new_assuming_finite(|r: (int, nat)| r.1 != 0 &&
+        spec_full_set::<(int, nat)>().filter(|r: (int, nat)| r.1 != 0 &&
             exists |i: int| 0 <= i && i < self.len() &&
                 (#[trigger]self[i]).spec_range() === r)
         //s.to_set().difference(empty_ranges())
@@ -475,7 +475,7 @@ impl<T: MemRangeInterface> MemRangeSeqInterface for Seq<T>
 
     open spec fn to_aligned_ranges_internal(&self) -> Set<(int, nat)>
     {
-        Set::new_assuming_finite(|r: (int, nat)|
+        spec_full_set::<(int, nat)>().filter(|r: (int, nat)|
             self.has_aligned_ranges_internal(r)
         )
     }

--- a/source/verismo/src/allocator/buddy.rs
+++ b/source/verismo/src/allocator/buddy.rs
@@ -248,7 +248,7 @@ impl SpecBuddyAllocator {
         &&& self.perms.contains_key((bucket as nat, oldlen))
         &&& self.perms.dom().remove((bucket as nat, oldlen)) === old_self.perms.dom()
         &&& old_self.perms =~~= Map::new(
-            Set::new_assuming_finite(|key| old_self.perms.contains_key(key)),
+            old_self.perms.dom(),
             |k: (nat, nat)|
                 if k.0 != bucket || k.1 < idx {
                     self.perms[k]
@@ -780,7 +780,7 @@ impl BuddyAllocator {
                     removed_perm =
                     removed_node_perm.trusted_into_raw().trusted_join(removed_free_perm);
                     let key_map = Map::new(
-                        Set::new_assuming_finite(
+                        spec_full_set::<(nat, nat)>().filter(
                             |k: (nat, nat)|
                                 k.0 < ORDER && k.1 < prev_self.free_lists[k.0 as int]@.len() && k
                                     !== (current_bucket as nat, (prev_list@.len() - 1) as nat),

--- a/source/verismo/src/arch/addr_s/page.rs
+++ b/source/verismo/src/arch/addr_s/page.rs
@@ -125,7 +125,6 @@ impl<T> SpecAddr<T> {
     pub proof fn lemma_to_set(&self, n: nat) -> (ret: Set<int>)
         ensures
             ret.len() == n,
-            ret.finite(),
             ret === self.to_set(n),
             n == 0 ==> ret.is_empty(),
     {
@@ -209,7 +208,6 @@ impl<T> SpecPage<T> {
     pub proof fn lemma_to_set(&self, n: nat) -> (ret: Set<int>)
         ensures
             ret.len() == n,
-            ret.finite(),
             ret === self.to_set(n),
             n == 0 <==> ret.is_empty(),
     {
@@ -382,7 +380,6 @@ impl<T> SpecMem<T> {
     pub proof fn lemma_to_set(&self) -> (ret: Set<int>)
         ensures
             ret.len() == self.len(),
-            ret.finite(),
             ret === self.to_set(),
             ret === self.first().to_set(self.len()),
     {

--- a/source/verismo/src/arch/ptram/ptram_s.rs
+++ b/source/verismo/src/arch/ptram/ptram_s.rs
@@ -95,7 +95,7 @@ impl GuestPTRam {
     // pt_rmp: is a RMP table with only spa whose gpa is of PTE type.
     pub open spec fn to_mem_map(&self, sysmap: SysMap, memid: MemID) -> MemMap<GuestVir, GuestPhy> {
         let map = Map::new(
-            Set::new_assuming_finite(
+            spec_full_set::<GVN>().filter(
                 |gvn: GVN|
                     gvn.is_valid() && self.map_entry(sysmap, memid, gvn, PTLevel::L0) is Some,
             ),

--- a/source/verismo/src/arch/ptram/ptram_u.rs
+++ b/source/verismo/src/arch/ptram/ptram_u.rs
@@ -178,7 +178,7 @@ impl GuestPTRam {
 
     pub open spec fn to_mem_map_ok(&self, memid: MemID) -> MemMap<GuestVir, GuestPhy> {
         let map = Map::new(
-            Set::new_assuming_finite(
+            spec_full_set::<GVN>().filter(
                 |gvn: GVN| gvn.is_valid() && self.map_entry_ok(memid, gvn, PTLevel::L0) is Some,
             ),
             |gvn: GVN| self.map_entry_ok(memid, gvn, PTLevel::L0)->Some_0,

--- a/source/verismo/src/arch/rmp/access_p.rs
+++ b/source/verismo/src/arch/rmp/access_p.rs
@@ -46,9 +46,7 @@ impl RmpEntry {
         let next = entry.trans(op).to_result();
         if (next !== entry) {
             assert(next@.perms =~~= super::perm_s::rmp_perm_init());
-            assert(next@.perms[VMPL::VMPL0] =~~= super::perm_s::PagePerm::new_assuming_finite(
-                |_p| true,
-            ));
+            assert(next@.perms[VMPL::VMPL0] =~~= spec_full_set::<super::perm_s::Perm>());
             assert(next@.perms[VMPL::VMPL0] =~~= entry@.perms[VMPL::VMPL0]);
             assert(next@.perms[VMPL::VMPL1].subset_of(entry@.perms[VMPL::VMPL1]));
         }

--- a/source/verismo/src/arch/rmp/db_u.rs
+++ b/source/verismo/src/arch/rmp/db_u.rs
@@ -87,7 +87,7 @@ pub open spec fn rmp_inv_memid_int(rmp: &RmpMap, memid: MemID) -> bool {
 
 pub open spec fn rmp_hv_update(rmp: &RmpMap, newrmp: RmpMap, memid: MemID) -> RmpMap {
     RmpMap::new(
-        Set::new_assuming_finite(|spn: SPN| rmp.dom().contains(spn)),
+        rmp.dom(),
         |spn: SPN| { rmp.spec_index(spn).rmpupdate(newrmp.spec_index(spn)).to_result() },
     )
 }

--- a/source/verismo/src/arch/rmp/entry_s.rs
+++ b/source/verismo/src/arch/rmp/entry_s.rs
@@ -13,7 +13,7 @@ impl HiddenRmpEntryForPSP {
         //&&& self.validated ==> (self.perms === preventry.perms && self.asid === preventry.asid && preventry.validated && self.vmsa == preventry.vmsa && self.size == preventry.size)
         //&&& (self !== preventry)  ==> ((self.perms === super::perm_s::rmp_perm_init()))
         &&& (self !== preventry) ==> {
-            &&& self.perms[VMPL::VMPL0] =~~= PagePerm::new_assuming_finite(|_p| true)
+            &&& self.perms[VMPL::VMPL0] =~~= spec_full_set::<super::perm_s::Perm>()
             &&& self.perms[VMPL::VMPL0] =~~= preventry.perms[VMPL::VMPL0]
             &&& self.perms[VMPL::VMPL1].subset_of(preventry.perms[VMPL::VMPL1])
             &&& self.perms[VMPL::VMPL2].subset_of(preventry.perms[VMPL::VMPL2])
@@ -67,9 +67,9 @@ impl HiddenRmpEntryForPSP {
     pub open spec fn is_valid(&self) -> bool {
         &&& (self.spec_asid() != 0 || !self.spec_assigned())
         &&& (!self.spec_validated() || (self.spec_assigned() && self.spec_asid() != 0))
-        &&& self.perms[VMPL::VMPL0] === Set::new_assuming_finite(
-            |_a| true,
-        )
+        &&& self.perms[VMPL::VMPL0] === spec_full_set::<
+            super::perm_s::Perm,
+        >()
         //&&& !self.validated ==> self.perms === super::perm_s::rmp_perm_init() Not Hold
 
     }

--- a/source/verismo/src/arch/rmp/perm_s.rs
+++ b/source/verismo/src/arch/rmp/perm_s.rs
@@ -94,10 +94,10 @@ verus! {
 #[verifier(inline)]
 pub open spec fn rmp_perm_init() -> RmpPerm {
     Map::new(
-        Set::new_assuming_finite(|vmpl: VMPL| true),
+        spec_full_set::<VMPL>(),
         |vmpl: VMPL|
             if vmpl is VMPL0 {
-                PagePerm::new_assuming_finite(|_p| true)
+                spec_full_set::<Perm>()
             } else {
                 PagePerm::empty()
             },
@@ -106,7 +106,7 @@ pub open spec fn rmp_perm_init() -> RmpPerm {
 
 #[verifier(inline)]
 pub open spec fn rmp_perm_is_init(p: RmpPerm) -> bool {
-    &&& p[VMPL::VMPL0] === PagePerm::new_assuming_finite(|_p| true)
+    &&& p[VMPL::VMPL0] === spec_full_set::<Perm>()
     &&& p[VMPL::VMPL1] === PagePerm::empty()
     &&& p[VMPL::VMPL2] === PagePerm::empty()
     &&& p[VMPL::VMPL3] === PagePerm::empty()
@@ -114,8 +114,8 @@ pub open spec fn rmp_perm_is_init(p: RmpPerm) -> bool {
 
 #[verifier(inline)]
 pub open spec fn rmp_perm_is_valid(p: RmpPerm) -> bool {
-    &&& p.index(VMPL::VMPL0) === PagePerm::new_assuming_finite(|_p| true)
-    &&& p.dom() === Set::new_assuming_finite(|_a| true)
+    &&& p.index(VMPL::VMPL0) === spec_full_set::<Perm>()
+    &&& p.dom() === spec_full_set::<VMPL>()
 }
 
 #[verifier(external_body)]

--- a/source/verismo/src/boot/linux/mod.rs
+++ b/source/verismo/src/boot/linux/mod.rs
@@ -532,11 +532,13 @@ pub fn load_bzimage_to_vmsa(
                 proof_bytes_add_is_constant_to(b1, b2, vmpl as nat);
                 assert(page_perm.bytes().is_constant_to(vmpl as nat));
             }
-            assert(old_prefer_mem.dom() =~~= Set::new_assuming_finite(
-                |i: int| entry.spec_start() <= i < entry.spec_end(),
+            assert(old_prefer_mem.dom() =~~= Set::<int>::range(
+                entry.spec_start() as int,
+                entry.spec_end() as int,
             ));
-            assert(prefer_mem.dom() =~~= Set::new_assuming_finite(
-                |i: int| entry.spec_start() <= i < entry.spec_end(),
+            assert(prefer_mem.dom() =~~= Set::<int>::range(
+                entry.spec_start() as int,
+                entry.spec_end() as int,
             ));
         }
         entry.page_perms = Tracked(prefer_mem);

--- a/source/verismo/src/linkedlist/mod.rs
+++ b/source/verismo/src/linkedlist/mod.rs
@@ -673,7 +673,7 @@ impl<T> LinkedList<T> where T: IsConstant + WellFormed + SpecSize + VTypeCast<Se
                     (j + 1) as nat
                 };
             let key_map = Map::<nat, nat>::new(
-                Set::new_assuming_finite(|j: nat| 0 <= j < self.ptrs@.len()),
+                Set::<nat>::range(0, self.ptrs@.len()),
                 |j: nat| convert(j),
             );
             assert forall|j: nat| key_map.dom().contains(j) implies self.perms@.dom().contains(
@@ -771,7 +771,7 @@ where
 
                 let convert = |j: nat| if j < i {j} else {(j+1) as nat};
                 let key_map = Map::<nat, nat>::new(
-                    Set::new_assuming_finite(|j: nat| 0 <= j < self.ptrs@.len()),
+                    Set::<nat>::range(0, self.ptrs@.len()),
                     |j: nat| convert(j)
                 );
                 assert forall |j: nat|
@@ -871,7 +871,7 @@ where
                     if j < i {j} else if j == i {(self.ptrs@.len() - 1) as nat} else {(j-1) as nat};
 
                 let key_map = Map::<nat, nat>::new(
-                    Set::new_assuming_finite(|j: nat| 0 <= j < self.ptrs@.len()),
+                    Set::<nat>::range(0, self.ptrs@.len()),
                     |j: nat| convert(j)
                 );
                 assert forall |j: nat|

--- a/source/verismo/src/ptr/snp/snp_u.rs
+++ b/source/verismo/src/ptr/snp/snp_u.rs
@@ -122,10 +122,7 @@ impl SwSnpMemAttr {
     pub open spec fn deterministic_pte(&self) -> bool {
         &&& self.pte.len() == 1
         &&& self.pte() === self.pte.last()
-        &&& self.guestmap =~~= Map::new(
-            Set::new_assuming_finite(|gva: int| true),
-            |gva: int| spec_va_to_pa(gva),
-        )
+        &&& self.guestmap =~~= Map::new(spec_full_set::<int>(), |gva: int| spec_va_to_pa(gva))
     }
 
     pub open spec fn is_vm_confidential(&self) -> bool {
@@ -274,7 +271,7 @@ impl SwSnpMemAttr {
             rmp: arbitrary::<RmpEntry>().spec_set_val(rmp_psp),
             pte: seq![PTAttr::spec_default()],
             is_pte: false,
-            guestmap: Map::new(Set::new_assuming_finite(|gva: int| true), |gva: int| gva),
+            guestmap: Map::new(spec_full_set::<int>(), |gva: int| gva),
             rmpmap: Map::empty(),
             sysmap: Map::empty(),
         }

--- a/source/verismo/src/security/mem.rs
+++ b/source/verismo/src/security/mem.rs
@@ -174,9 +174,7 @@ pub open spec fn spec_contains_page_perms(
 ) -> bool {
     &&& forall|i| #[trigger]
         page_perms.contains_key(i) ==> spec_contains_page_perm(page_perms, i, osperm)
-    &&& page_perms.dom() =~~= Set::new_assuming_finite(
-        |i: int| start_page <= i < start_page + npages,
-    )
+    &&& page_perms.dom() =~~= Set::<int>::range(start_page as int, (start_page + npages) as int)
 }
 
 } // verus!
@@ -308,8 +306,9 @@ pub fn osmem_adjust(
     }
     let ghost old_page_perms = entry.page_perms@;
     proof {
-        assert(old_page_perms.dom() =~~= Set::new_assuming_finite(
-            |i| start_page as int <= i < start_page + npages,
+        assert(old_page_perms.dom() =~~= Set::<int>::range(
+            start_page as int,
+            (start_page + npages) as int,
         ));
     }
     let Tracked(mut page_perms) = entry.page_perms;
@@ -367,8 +366,9 @@ pub fn osmem_adjust(
     proof {
         assert(entry.start_page.spec_valid_pn_with(npages as nat));
         assert(entry.page_perms@.dom() =~~= old_page_perms.dom());
-        assert(entry.page_perms@.dom() =~~= Set::new_assuming_finite(
-            |i| start_page as int <= i < start_page + npages,
+        assert(entry.page_perms@.dom() =~~= Set::<int>::range(
+            start_page as int,
+            (start_page + npages) as int,
         ));
         assert forall|i| #[trigger] page_perms.contains_key(i) implies spec_contains_page_perm(
             page_perms,
@@ -428,7 +428,7 @@ pub fn osmem_add(
 {
     let tracked mut page_perms = page_perms;
     let tracked mut page_perms = page_perms.tracked_remove_keys(
-        Set::new_assuming_finite(|k| start_page <= k < (start_page + npages)),
+        Set::<int>::range(start_page as int, (start_page + npages) as int),
     );
     let ghost old_page_perms = page_perms;
     if !shared {
@@ -478,8 +478,9 @@ pub fn osmem_add(
                     assert(os_mem_valid_snp(osperm, page_perms[k]@.snp()));
                     assert(page_perms[k]@.bytes() === old_page_perms[k]@.bytes());
                 }
-                assert(page_perms.dom() =~~= Set::new_assuming_finite(
-                    |k| start_page <= k < (start_page + npages),
+                assert(page_perms.dom() =~~= Set::<int>::range(
+                    start_page as int,
+                    (start_page + npages) as int,
                 ));
                 assert(spec_contains_page_perms(
                     page_perms,
@@ -540,13 +541,13 @@ pub fn osmem_entry_split(entry: OSMemEntry, start: usize, npages: usize) -> (ret
 {
     let Tracked(mut page_perms) = entry.page_perms;
     let tracked perms0 = page_perms.tracked_remove_keys(
-        Set::new_assuming_finite(|i| entry.spec_start() <= i < start),
+        Set::<int>::range(entry.spec_start() as int, start as int),
     );
     let tracked perms1 = page_perms.tracked_remove_keys(
-        Set::new_assuming_finite(|i| start <= i < start + npages),
+        Set::<int>::range(start as int, (start + npages) as int),
     );
     let tracked perms2 = page_perms.tracked_remove_keys(
-        Set::new_assuming_finite(|i| start + npages <= i < entry.spec_end()),
+        Set::<int>::range((start + npages) as int, entry.spec_end() as int),
     );
     let entry0 = OSMemEntry {
         start_page: entry.start_page,
@@ -1091,8 +1092,9 @@ fn _lock_kernel(
                     assert(spec_contains_page_perm(page_perms, i, mid.spec_osperm()));
                     assert(page_perms[i]@.wf_range((i.to_addr(), PAGE_SIZE as nat)));
                 }
-                assert(page_perms.dom() =~~= Set::new_assuming_finite(
-                    |i| tmp_start <= i < (tmp_start + tmp_npages),
+                assert(page_perms.dom() =~~= Set::<int>::range(
+                    tmp_start as int,
+                    (tmp_start + tmp_npages) as int,
                 ));
             }
             rmpadjmem(tmp_start, tmp_npages, attr, Tracked(snpcore), Tracked(&mut page_perms));
@@ -1128,8 +1130,9 @@ fn clear_kern_if_private(entry: OSMemEntry, Tracked(cs): Tracked<&mut SnpCoreSha
     let npages: usize = npages.into();
     let ghost start = tmp_start;
     proof {
-        assert(page_perms.dom() =~~= Set::new_assuming_finite(
-            |i| tmp_start <= i < (tmp_start + npages),
+        assert(page_perms.dom() =~~= Set::<int>::range(
+            tmp_start as int,
+            (tmp_start + npages) as int,
         ));
     }
     (new_strlit("\nClear Kern_exe "), (tmp_start, npages)).leak_debug();
@@ -1210,8 +1213,9 @@ fn clear_kern_if_private(entry: OSMemEntry, Tracked(cs): Tracked<&mut SnpCoreSha
                     assert(page_perm@.bytes().is_constant_to(RICHOS_VMPL as nat));
                 }
             }
-            assert(new_page_perms.dom() =~~= Set::new_assuming_finite(
-                |i: int| start <= i < tmp_start + 1,
+            assert(new_page_perms.dom() =~~= Set::<int>::range(
+                start as int,
+                (tmp_start + 1) as int,
             ));
         }
         tmp_start = tmp_start + 1;

--- a/source/verismo/src/snp/ghcb/proto_impl.rs
+++ b/source/verismo/src/snp/ghcb/proto_impl.rs
@@ -103,7 +103,7 @@ pub fn ghcb_change_page_state_via_pg(
         proof {
             ghcbpage_perm0.tracked_insert(0, ghcbpage_perm);
         }
-        let ghost subdom = Set::new_assuming_finite(|i| ppage + offset <= i < ppage + offset + n);
+        let ghost subdom = Set::<int>::range(ppage + offset, (ppage + offset + n) as int);
         assert forall|i| #[trigger] subdom.contains(i) implies page_perms.contains_key(i) by {
             assert(old_page_perms[i] === page_perms[i]);
             assert(ppage + offset <= i < ppage + npages);

--- a/source/verismo_tspec/src/fmap.rs
+++ b/source/verismo_tspec/src/fmap.rs
@@ -33,7 +33,7 @@ impl<K, V> FMap<K, V> {
 
     #[verifier(inline)]
     pub open spec fn update(&self, fv: spec_fn(K) -> V) -> Self {
-        self.spec_set_map(Map::new(Set::new_assuming_finite(|K| true), |k: K| fv(k)))
+        self.spec_set_map(Map::new(spec_full_set::<K>(), |k: K| fv(k)))
     }
 
     #[verifier(inline)]

--- a/source/verismo_tspec/src/lib.rs
+++ b/source/verismo_tspec/src/lib.rs
@@ -114,6 +114,15 @@ pub broadcast group group_tspec_default {
     axiom_size_from_cast_bytes_def,
     axiom_max_count_size_rel,
     axiom_set_full_max_count_rel,
+    axiom_full_set,
+    vstd::set::lemma_set_filter,
+    // Int-range set membership/length (range_to_set / range2set)
+    lemma_range_to_set_contains,
+    lemma_range_to_set_len,
+    vstd::set_lib::range_set_properties,
+    // set_op / set_uop image-set membership
+    lemma_set_uop_contains,
+    lemma_set_op_contains,
     // FMap
     FMap::axiom_inv,
     FMap::axiom_equal,

--- a/source/verismo_tspec/src/map_lib.rs
+++ b/source/verismo_tspec/src/map_lib.rs
@@ -32,10 +32,7 @@ pub proof fn tracked_seq_remove<T>(tracked m: &mut Map<nat, T>, i: nat, n: nat) 
         } else {
             (j + 1) as nat
         };
-    let key_map = Map::<nat, nat>::new(
-        Set::new_assuming_finite(|j: nat| 0 <= j < (n - 1)),
-        |j: nat| convert(j),
-    );
+    let key_map = Map::<nat, nat>::new(Set::<nat>::range(0, (n - 1) as nat), |j: nat| convert(j));
     assert forall|j: nat| key_map.contains_key(j) implies m.contains_key(convert(j)) by {
         assert(oldm.contains_key(j));
         assert(oldm.contains_key(j + 1));
@@ -66,10 +63,7 @@ pub proof fn tracked_seq_insert<T>(tracked m: &mut Map<nat, T>, i: nat, tracked 
         } else {
             (j - 1) as nat
         };
-    let key_map = Map::<nat, nat>::new(
-        Set::new_assuming_finite(|j: nat| 0 <= j < n + 1),
-        |j: nat| convert(j),
-    );
+    let key_map = Map::<nat, nat>::new(Set::<nat>::range(0, (n + 1) as nat), |j: nat| convert(j));
     assert forall|j: nat| key_map.contains_key(j) implies m.contains_key(convert(j)) by {
         if j < i {
             assert(oldm.contains_key(j));

--- a/source/verismo_tspec/src/range_set.rs
+++ b/source/verismo_tspec/src/range_set.rs
@@ -1,11 +1,12 @@
 use vstd::prelude::*;
+use vstd::set_lib::{lemma_int_range, range_set_properties, set_int_range};
 
 use super::*;
 
 verus! {
 
 pub open spec fn range_to_set(first: int, n: nat) -> Set<int> {
-    Set::new_assuming_finite(|i: int| first <= i < first + (n as int))
+    set_int_range(first, first + n)
 }
 
 pub open spec fn range(first: int, end: int) -> (int, nat) {
@@ -18,7 +19,24 @@ pub open spec fn range(first: int, end: int) -> (int, nat) {
 
 #[verifier(inline)]
 pub open spec fn range2set(range: (int, nat)) -> Set<int> {
-    Set::new_assuming_finite(|i: int| within_range(i, range))
+    set_int_range(range.0, range.0 + range.1)
+}
+
+/// Membership for `range_to_set`/`range2set`, kept broadcast so downstream
+/// proofs see it automatically (replaces the deprecated `new_assuming_finite`).
+pub broadcast proof fn lemma_range_to_set_contains(first: int, n: nat, v: int)
+    ensures
+        #[trigger] range_to_set(first, n).contains(v) <==> first <= v < first + n,
+{
+    broadcast use range_set_properties;
+
+}
+
+pub broadcast proof fn lemma_range_to_set_len(first: int, n: nat)
+    ensures
+        (#[trigger] range_to_set(first, n)).len() == n,
+{
+    lemma_int_range(first, first + n);
 }
 
 pub trait VRange {
@@ -62,38 +80,10 @@ pub open spec fn after_range(x: (int, nat), range: (int, nat)) -> bool {
 pub proof fn lemma_to_set(first: int, n: nat) -> (ret: Set<int>)
     ensures
         ret.len() == n,
-        ret.finite(),
         ret === range_to_set(first, n),
-    decreases n,
 {
-    let ret = range_to_set(first, n);
-    if n == 0 {
-        assert forall|v: int| !range_to_set(first, n).contains(v) by {
-            assert(!(first < v && v < first));
-        }
-        assert(range_to_set(first, n) =~= Set::empty());
-        //assert(ret=~~=(Set::empty()));
-    }
-    if n > 0 {
-        let prev = lemma_to_set(first, (n - 1) as nat);
-        assert(range_to_set(first, n) =~~= (range_to_set(first, (n - 1) as nat).insert(
-            first + (n - 1),
-        ))) by {
-            assert forall|v| range_to_set(first, n).contains(v) implies range_to_set(
-                first,
-                (n - 1) as nat,
-            ).contains(v) || v === (first + (n - 1)) by {
-                if (first <= v < first + n - 1) {
-                    assert(range_to_set(first, (n - 1) as nat).contains(v));
-                } else {
-                }
-            }
-            assert forall|v|
-                range_to_set(first, (n - 1) as nat).contains(v) || v === (first + (n
-                    - 1)) implies range_to_set(first, n).contains(v) by {}
-        }
-    }
-    ret
+    lemma_range_to_set_len(first, n);
+    range_to_set(first, n)
 }
 
 pub open spec fn range_disjoint(f1: int, n1: nat, f2: int, n2: nat) -> bool {

--- a/source/verismo_tspec/src/security/sectype.rs
+++ b/source/verismo_tspec/src/security/sectype.rs
@@ -118,7 +118,7 @@ impl<T, M> SecType<T, M> {
     #[verifier(external_body)]
     pub exec fn upgrade_secret(&mut self, Ghost(vmpl): Ghost<nat>)
         requires
-            old(self)@.valsets[vmpl] =~~= Set::new_assuming_finite(|a| true) || old(self)@.labels[vmpl] is TrustedRandom,
+            old(self)@.valsets[vmpl] =~~= spec_full_set() || old(self)@.labels[vmpl] is TrustedRandom,
         ensures
             self@ == old(self)@.spec_set_labels(old(self)@.labels.insert(vmpl, DataLabel::Secret)),
     {
@@ -188,7 +188,7 @@ impl<T, M> SecType<T, M> {
 
 impl<T, M> IsFullSecret for SpecSecType<T, M> {
     open spec fn is_fullsecret_to(&self, vmpl: nat) -> bool {
-        self.valsets[vmpl] =~~= Set::new_assuming_finite(|a| true)
+        self.valsets[vmpl] =~~= spec_full_set()
     }
 }
 
@@ -280,12 +280,11 @@ impl<T, M> SpecSecType<T, M> {
         vmpl: nat,
     ) -> bool {
         //&&& valsets[vmpl] =~~= Set::full() ==> labels[vmpl] is Symbol
-        &&& labels[vmpl] is TrustedRandom ==> valsets[vmpl] =~~= Set::new_assuming_finite(|a| true)
-        &&& labels[vmpl] is Secret ==> valsets[vmpl] =~~= Set::new_assuming_finite(|a| true)
+        &&& labels[vmpl] is TrustedRandom ==> valsets[vmpl] =~~= spec_full_set()
+        &&& labels[vmpl] is Secret ==> valsets[vmpl] =~~= spec_full_set()
         &&& labels.contains_key(vmpl)
         &&& valsets.contains_key(vmpl)
         &&& valsets[vmpl].len() > 0
-        &&& valsets[vmpl].finite()
     }
 
     pub open spec fn wf_value(&self) -> bool {
@@ -306,10 +305,10 @@ impl<T, M> SpecSecType<T, M> {
             val: op(self.val, rhs.val),
             _unused: rhs._unused,
             valsets: Map::new(
-                Set::new_assuming_finite(|vmpl| 1 <= vmpl <= 4),
+                set![1, 2, 3, 4],
                 |vmpl| set_op(self.valsets[vmpl], rhs.valsets[vmpl], op),
             ),
-            labels: Map::new(Set::new_assuming_finite(|vmpl| 1 <= vmpl <= 4), |vmpl| DataLabel::Symbol),
+            labels: Map::new(set![1, 2, 3, 4], |vmpl| DataLabel::Symbol),
         }
     }
 
@@ -330,12 +329,11 @@ impl<T, M> SpecSecType<T, M> {
     {
         let ret = self.bop_new(rhs, op);
         assert forall|i| 1 <= i <= 4 implies ret.valsets[i].len() <= self.valsets[i].len()
-            * rhs.valsets[i].len() && ret.valsets[i].len() >= 1 && ret.valsets[i].finite()
+            * rhs.valsets[i].len() && ret.valsets[i].len() >= 1
             && #[trigger] SpecSecType::<T2, M>::wf_vmpl(ret.valsets, ret.labels, i) by {
             lemma_setop_len(self.valsets[i], rhs.valsets[i], op);
             assert(ret.valsets[i].len() <= self.valsets[i].len() * rhs.valsets[i].len());
             assert(ret.valsets[i].len() >= 1);
-            assert(ret.valsets[i].finite());
             assert(SpecSecType::<T2, M>::wf_vmpl(ret.valsets, ret.labels, i));
             //assert(set_op(self.valsets[i], rhs.valsets[i], op).len() <= 1);
         }
@@ -344,6 +342,8 @@ impl<T, M> SpecSecType<T, M> {
             assert(ret._is_constant()) by {
                 assert forall|i: nat| 1 <= i <= 4 implies
                     #[trigger] ret.valsets[i] =~~= set![ret.val] by {
+                    broadcast use {lemma_set_op_contains, lemma_set_uop_contains};
+
                     lemma_setop_len(self.valsets[i], rhs.valsets[i], op);
                     assert(self.valsets[i] =~~= set![self.val]);
                     assert(rhs.valsets[i] =~~= set![rhs.val]);
@@ -376,6 +376,8 @@ impl<T, M> SpecSecType<T, M> {
         if self._is_constant() {
             assert forall|i: nat| 1 <= i <= 4 implies
                 #[trigger] ret.valsets[i] =~~= set![ret.val] by {
+                broadcast use {lemma_set_op_contains, lemma_set_uop_contains};
+
                 let other = SpecSecType::<T, M>::constant(arbitrary::<T>());
                 lemma_setop_len(self.valsets[i], other.valsets[i], uop_to_bop(op));
                 assert(self.valsets[i] =~~= set![self.val]);
@@ -413,8 +415,8 @@ impl<T, M> SpecSecType<T, M> {
         SpecSecType {
             val,
             _unused: None,
-            valsets: Map::new(Set::new_assuming_finite(|vmpl| 1 <= vmpl <= 4), |vmpl| Set::<T>::empty().insert(val)),
-            labels: Map::new(Set::new_assuming_finite(|vmpl| 1 <= vmpl <= 4), |vmpl| DataLabel::Symbol),
+            valsets: Map::new(set![1, 2, 3, 4], |vmpl| Set::<T>::empty().insert(val)),
+            labels: Map::new(set![1, 2, 3, 4], |vmpl| DataLabel::Symbol),
         }
     }
 }

--- a/source/verismo_tspec/src/setlib.rs
+++ b/source/verismo_tspec/src/setlib.rs
@@ -7,10 +7,10 @@ verus! {
 
 pub proof fn lemma_ret_is_empty<A>(s: Set<A>) -> (b: bool)
     ensures
-        b <==> s.finite() && s.len() == 0,
+        b <==> s.len() == 0,
         b <==> s =~= Set::empty(),
 {
-    if s.finite() && s.len() == 0 {
+    if s.len() == 0 {
         s.lemma_len0_is_empty();
     }
     s =~= Set::empty()
@@ -33,30 +33,86 @@ pub proof fn lemma_union<A>(s1: Set<A>, s2: Set<A>)
     let ss2 = s1.union(s2);
 }
 
-pub open spec fn convert_set<A, B>(s: Set<A>, f: spec_fn(B) -> A) -> Set<B> {
-    Set::new_assuming_finite(|a| s.contains(f(a)))
-}
-
 pub open spec fn uop_to_bop<T1, T2, T3>(op: spec_fn(T1) -> T3) -> spec_fn(T1, T2) -> T3 {
     |v1: T1, v2: T2| op(v1)
 }
 
-#[verifier(inline)]
+// Image of `s1` under `op_fn`: `{ op_fn(v1) : v1 in s1 }`. Defined via
+// `Set::map` so it is finite by construction (was `new_assuming_finite`).
+pub open spec fn set_uop<T1, T2>(s1: Set<T1>, op_fn: spec_fn(T1) -> T2) -> Set<T2> {
+    s1.map(op_fn)
+}
+
+// Curried inner mapping used by `set_op`: `v1 |-> { op_fn(v1, v2) : v2 in s2 }`.
+// Naming it (instead of an inline closure) lets proofs reference the exact same
+// function value that `set_op`'s definition uses.
+pub open spec fn set_op_map_fn<T1, T2, T3>(s2: Set<T2>, op_fn: spec_fn(T1, T2) -> T3) -> spec_fn(
+    T1,
+) -> Set<T3> {
+    |v1: T1| set_op1(v1, s2, op_fn)
+}
+
+// Image of the product `s1 x s2` under `op_fn`. Built via `map`/`flatten` so
+// it is finite by construction (was `new_assuming_finite`).
 pub open spec fn set_op<T1, T2, T3>(s1: Set<T1>, s2: Set<T2>, op_fn: spec_fn(T1, T2) -> T3) -> Set<
     T3,
 > {
-    Set::new_assuming_finite(
-        |val: T3| exists|v1, v2| s1.contains(v1) && s2.contains(v2) && val === op_fn(v1, v2),
-    )
+    s1.map(set_op_map_fn(s2, op_fn)).flatten()
 }
 
-#[verifier(inline)]
-pub open spec fn set_uop<T1, T2>(s1: Set<T1>, op_fn: spec_fn(T1) -> T2) -> Set<T2> {
-    Set::new_assuming_finite(
-        |val: T2| exists|v1| s1.contains(v1) && val === op_fn(v1),
-    )
-    //set_op(s1, Set::empty().insert(arbitrary::<T1>()), uop_to_bop(op_fn))
+pub broadcast proof fn lemma_set_uop_contains<T1, T2>(s1: Set<T1>, op_fn: spec_fn(T1) -> T2, v: T2)
+    ensures
+        #[trigger] set_uop(s1, op_fn).contains(v) <==> exists|v1: T1|
+            s1.contains(v1) && v === op_fn(v1),
+{
+    broadcast use Set::lemma_map_contains;
 
+}
+
+pub broadcast proof fn lemma_set_op_contains<T1, T2, T3>(
+    s1: Set<T1>,
+    s2: Set<T2>,
+    op_fn: spec_fn(T1, T2) -> T3,
+    v: T3,
+)
+    ensures
+        #[trigger] set_op(s1, s2, op_fn).contains(v) <==> exists|v1: T1, v2: T2|
+            s1.contains(v1) && s2.contains(v2) && v === op_fn(v1, v2),
+{
+    let g = set_op_map_fn(s2, op_fn);
+    let mapped = s1.map(g);
+    broadcast use {Set::lemma_map_contains, Set::lemma_flatten_contains};
+
+    assert forall|v1: T1|
+        #![trigger s1.contains(v1)]
+        g(v1) === set_op1(v1, s2, op_fn) && (set_op1(v1, s2, op_fn).contains(v) <==> (exists|v2: T2|
+
+            s2.contains(v2) && v === op_fn(v1, v2))) by {
+        lemma_set_uop_contains(s2, |v2: T2| op_fn(v1, v2), v);
+    }
+    if set_op(s1, s2, op_fn).contains(v) {
+        assert(set_op(s1, s2, op_fn) === mapped.flatten());
+        assert(mapped.flatten().contains(v));
+        mapped.lemma_flatten_contains(v);
+        assert(exists|s: Set<T3>| mapped.contains(s) && s.contains(v));
+        let s = choose|s: Set<T3>| mapped.contains(s) && s.contains(v);
+        assert(mapped.contains(s) && s.contains(v));
+        s1.lemma_map_contains(g, s);
+        assert(exists|v1: T1| s1.contains(v1) && s === g(v1));
+        let v1 = choose|v1: T1| s1.contains(v1) && s === g(v1);
+        assert(s1.contains(v1) && g(v1).contains(v));
+    }
+    if exists|v1: T1, v2: T2| s1.contains(v1) && s2.contains(v2) && v === op_fn(v1, v2) {
+        let (v1, v2) = choose|v1: T1, v2: T2|
+            s1.contains(v1) && s2.contains(v2) && v === op_fn(v1, v2);
+        assert(g(v1).contains(v)) by {
+            assert(s2.contains(v2) && v === op_fn(v1, v2));
+        }
+        assert(mapped.contains(g(v1))) by {
+            s1.lemma_map_contains(g, g(v1));
+            assert(s1.contains(v1) && g(v1) === g(v1));
+        }
+    }
 }
 
 spec fn set_bop_recursive<T1, T2, T3>(
@@ -64,20 +120,14 @@ spec fn set_bop_recursive<T1, T2, T3>(
     s2: Set<T2>,
     op_fn: spec_fn(T1, T2) -> T3,
 ) -> Set<T3>
-    recommends
-        s1.finite(),
     decreases s1.len(),
 {
-    if s1.finite() {
-        if !s1.is_empty() {
-            let ss1 = s1.remove(s1.choose());
-            if (ss1.len() < s1.len()) {
-                set_bop_recursive(ss1, s2, op_fn).union(set_op1(s1.choose(), s2, op_fn))
-            } else {
-                // unreacheable
-                Set::empty()
-            }
+    if !s1.is_empty() {
+        let ss1 = s1.remove(s1.choose());
+        if (ss1.len() < s1.len()) {
+            set_bop_recursive(ss1, s2, op_fn).union(set_op1(s1.choose(), s2, op_fn))
         } else {
+            // unreacheable
             Set::empty()
         }
     } else {
@@ -86,7 +136,7 @@ spec fn set_bop_recursive<T1, T2, T3>(
 }
 
 #[verifier(inline)]
-spec fn set_op1<T1, T2, T3>(v1: T1, s2: Set<T2>, op_fn: spec_fn(T1, T2) -> T3) -> Set<T3> {
+pub open spec fn set_op1<T1, T2, T3>(v1: T1, s2: Set<T2>, op_fn: spec_fn(T1, T2) -> T3) -> Set<T3> {
     set_uop(s2, |v2| op_fn(v1, v2))
 }
 
@@ -94,11 +144,9 @@ proof fn lemma_setop1<T1, T2, T3>(v1: T1, s2: Set<T2>, op_fn: spec_fn(T1, T2) ->
     T3,
 >)
     requires
-        s2.finite(),
     ensures
         ret =~~= set_op1(v1, s2, op_fn),
         ret.len() <= s2.len(),
-        ret.finite(),
     decreases s2.len(),
 {
     let ret = set_op1(v1, s2, op_fn);
@@ -135,14 +183,14 @@ proof fn lemma_setop_3_union<T1, T2, T3>(
     requires
         s1.len() > 0,
         s1.contains(vv1),
-        s1.finite(),
-        s2.finite(),
     ensures
         ret.0 =~~= set_op(s1, s2, op_fn),
         ret.1 =~~= set_op(s1.remove(vv1), s2, op_fn),
         ret.2 =~~= set_op1(vv1, s2, op_fn),
         ret.0 =~~= ret.1.union(ret.2),
 {
+    broadcast use {lemma_set_op_contains, lemma_set_uop_contains};
+
     let r0 = set_op(s1, s2, op_fn);
     let r1 = set_op(s1.remove(vv1), s2, op_fn);
     let r2 = lemma_setop1(vv1, s2, op_fn);
@@ -164,23 +212,21 @@ pub proof fn lemma_op_exchange<T1, T2, T3>(
 ) -> (ret: Set<T3>)
     requires
         s1.len() > 0,
-        s1.finite(),
-        s2.finite(),
     ensures
         ret =~~= set_op(s1, s2, op_fn),
         ret =~~= set_op(s2, s1, exchange_spec_fn(op_fn)),
 {
+    broadcast use {lemma_set_op_contains, lemma_set_uop_contains};
+
     set_op(s1, s2, op_fn)
 }
 
 pub proof fn lemma_set_uop_len<T1, T2>(s1: Set<T1>, op_fn: spec_fn(T1) -> T2) -> (ret: Set<T2>)
     requires
-        s1.finite(),
     ensures
         ret =~~= set_uop(s1, op_fn),
         (ret.len() == 0) == (s1.len() == 0),
         ret.len() <= s1.len(),
-        ret.finite(),
     decreases s1.len(),
 {
     let ret = set_uop(s1, op_fn);
@@ -203,13 +249,10 @@ proof fn lemma_set_bop_len_recursive<T1, T3, T2>(
     op_fn: spec_fn(T1, T2) -> T3,
 ) -> (ret: Set<T3>)
     requires
-        s1.finite(),
-        s2.finite(),
     ensures
         ret =~~= set_bop_recursive(s1, s2, op_fn),
         (ret.len() == 0) == (s1.len() == 0 || s2.len() == 0),
         ret.len() <= s1.len() * s2.len(),
-        ret.finite(),
     decreases s1.len(),
 {
     let ret = set_bop_recursive(s1, s2, op_fn);
@@ -248,8 +291,6 @@ proof fn lemma_setop_eq_recursive<T1, T2, T3>(
     op_fn: spec_fn(T1, T2) -> T3,
 ) -> (ret: Set<T3>)
     requires
-        s1.finite(),
-        s2.finite(),
     ensures
         ret =~~= set_op(s1, s2, op_fn),
         ret =~~= set_bop_recursive(s1, s2, op_fn),
@@ -273,13 +314,10 @@ pub proof fn lemma_setop_len<T1, T2, T3>(
     op_fn: spec_fn(T1, T2) -> T3,
 ) -> (ret: Set<T3>)
     requires
-        s1.finite(),
-        s2.finite(),
     ensures
         ret =~~= set_op(s1, s2, op_fn),
         (ret.len() == 0) == (s1.len() == 0 || s2.len() == 0),
         ret.len() <= s1.len() * s2.len(),
-        ret.finite(),
 {
     let ret = set_op(s1, s2, op_fn);
     lemma_setop_eq_recursive(s1, s2, op_fn);

--- a/source/verismo_tspec/src/size_s.rs
+++ b/source/verismo_tspec/src/size_s.rs
@@ -82,10 +82,22 @@ pub broadcast proof fn axiom_max_count_size_rel<T>()
 {
 }
 
+// The full set of all values of an exec type `T`. Every exec type is finite
+// (see `axiom_full_set`), so this is a proper finite `Set<T>`; it replaces the
+// deprecated `Set::new_assuming_finite(|a: T| true)` for generic `T`.
+pub uninterp spec fn spec_full_set<T>() -> Set<T>;
+
+#[verifier(external_body)]
+pub broadcast proof fn axiom_full_set<T>(a: T)
+    ensures
+        #[trigger] spec_full_set::<T>().contains(a),
+{
+}
+
 #[verifier(external_body)]
 pub broadcast proof fn axiom_set_full_max_count_rel<T>()
     ensures
-        Set::<T>::new_assuming_finite(|a: T| true).len() == #[trigger] spec_max_count::<T>(),
+        (#[trigger] spec_full_set::<T>()).len() == spec_max_count::<T>(),
 {
 }
 


### PR DESCRIPTION
Migrate all uses of the deprecated `Set::new_assuming_finite` and the always-true `Set::finite()` to non-deprecated constructs:

- Integer/nat index ranges -> `Set::<int>::range` / `Set::<nat>::range` (membership/length via the broadcast `range_set_properties`).
- Map/RMP domain subsets (`|k| m.contains_key(k)`, `|spn| rmp.dom().contains(spn)`) -> `m.dom()` / `rmp.dom()`.
- Product/image sets in `setlib` (`set_uop`/`set_op`) -> `Set::map` and `Set::map(..).flatten()`, so they are finite by construction; added proven (non-external) membership lemmas `lemma_set_uop_contains` / `lemma_set_op_contains`.
- "Full set of an exec type T" (generic T, finite enums, and the total int-domain guest map) -> a single `spec_full_set::<T>()` helper backed by the explicit `axiom_full_set` membership axiom, replacing the hidden `assume` inside `new_assuming_finite`. Predicate subsets over such types use `spec_full_set::<T>().filter(pred)`.
- Removed always-true `.finite()` ensures/guards.

Registered the new membership lemmas and `vstd::set::lemma_set_filter` in `group_tspec_default` so they are automatically available downstream.

Verifies clean with no deprecation warnings:
- verismo_tspec: 856 verified, 0 errors
- verismo:       1281 verified, 0 errors