### PR TITLE
Update Verus to the 2026-08-02 release

### DIFF
--- a/source/verismo_tspec/src/math/align_s.rs
+++ b/source/verismo_tspec/src/math/align_s.rs
@@ -71,6 +71,8 @@ pub proof fn proof_align_down(val: nat, align: nat) -> (ret: (u64, u64, u64))
         requires
             bits < 64,
     ;
+    // Required to rewrite `val - val % align` as `val / align * align`.
+    proof_div_mod_rel(val as int, align as int);
     (mask, bits, ret as u64)
 }
 

--- a/tools/install_verus
+++ b/tools/install_verus
@@ -13,9 +13,9 @@ set -euo pipefail
 trap 'echo "Error at line $LINENO: $BASH_COMMAND" >&2' ERR
 
 # Verus release version and commit hash
-VERUS_VERSION=0.2026.07.27.31579f0
+VERUS_VERSION=0.2026.08.02.b677dd5
 VERUS_RELEASE_TAG=release/$VERUS_VERSION
-DEFAULT_VERUS_REV=31579f0b8542a8a9ae4ae5604c16107ccde23ef2
+DEFAULT_VERUS_REV=b677dd5a766f25f56e9aa1e32621aa4e53304b47
 VERUS_RUST_VERSION=1.97.1
 
 # Verusfmt version


### PR DESCRIPTION
That release bundles Z3 4.16.0 (was 4.12.5). `proof_align_down` had been relying on the solver to derive the euclidean identity `val - val % align == val / align * align` on its own; Z3 4.16.0 no longer finds it, which broke that postcondition and the two bit-mask postconditions chained off it.

Invoke `proof_div_mod_rel` to state the identity explicitly instead of depending on nonlinear heuristics.